### PR TITLE
Restructure footer with nav links and cleaner spacing

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -27,9 +27,14 @@
   </script>
   <div class="content-wide footer-bar">
     <div>
+      <ul class="footer-nav">
+        {% for item in site.data.nav.docs %}
+          {% if item.url %}
+            <li><a href="{{ site.baseurl }}{{ item.url }}">{{ item.title }}</a></li>
+          {% endif %}
+        {% endfor %}
+      </ul>
       <p>
-        <a href="{{ site.baseurl}}/">{{ site.title }}</a>
-        &middot;
         <a href="https://my.scangov.com/public/key6541-1749843847485/lukefretwell-com/report">
           ScanGov Scorecard <i class="fa-solid fa-star" aria-hidden="true"></i>
         </a>

--- a/css/style.css
+++ b/css/style.css
@@ -91,6 +91,7 @@
     .jumbotron-default wa-button { margin-top: 0; }
     .home-section-inner wa-button { margin-top: 0; }
     .subscribe { right: 0.75rem; bottom: 0; }
+    .footer-nav { flex-direction: column; gap: 0.25rem; }
 }
 
 
@@ -442,9 +443,25 @@ small { font-size: 0.85rem; }
     border-top: 0.0625rem solid var(--site-border);
     margin-top: 2rem;
     padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
 }
 
-.footer-bar p { margin: 0; }
+.footer-nav {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0 1rem;
+    font-size: 0.8rem;
+    font-family: var(--site-font-accent);
+}
+
+.footer-nav li { padding: 0; margin: 0; }
+
+.footer-bar > div > * { margin-top: 0.75rem; }
+.footer-bar > div > *:first-child { margin-top: 0; }
+.footer-bar p { padding: 0; }
 
 /* Card quote (what-they-say) */
 


### PR DESCRIPTION
Add horizontal nav list to footer, move ScanGov Scorecard to its own line, remove Luke Fretwell link, and add uniform vertical spacing with matching top and bottom padding.