### PR TITLE
Show only site name in title on home page

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests">
 <meta name="referrer" content="strict-origin-when-cross-origin">
-<title>{% if page.title %}{{ page.title | escape }} - {{ site.title | escape }}{% else %}{{ site.title | escape }}{% endif %}</title>
+<title>{% if page.layout == 'home' %}{{ page.title | escape }}{% elsif page.title %}{{ page.title | escape }} - {{ site.title | escape }}{% else %}{{ site.title | escape }}{% endif %}</title>
 <meta name="description" content="{% if page.description %}{{ page.description | escape }}{% elsif page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description | escape }}{% endif %}">
 <meta name="keywords" content="{% if page.tags %}{{ page.tags | join: ', ' }}{% endif %}{% if page.categories %}{% if page.tags %}, {% endif %}{{ page.categories | join: ', ' }}{% endif %}">
 <meta name="author" content="{{ site.author }}">
@@ -21,7 +21,7 @@
 
 <!-- Open Graph Meta Tags -->
 <meta property="og:type" content="{% if page.collection == 'posts' %}article{% else %}website{% endif %}">
-<meta property="og:title" content="{% if page.title %}{{ page.title | escape }} - {{ site.title | escape }}{% else %}{{ site.title | escape }}{% endif %}">
+<meta property="og:title" content="{% if page.layout == 'home' %}{{ page.title | escape }}{% elsif page.title %}{{ page.title | escape }} - {{ site.title | escape }}{% else %}{{ site.title | escape }}{% endif %}">
 <meta property="og:description" content="{% if page.description %}{{ page.description | escape }}{% elsif page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description | escape }}{% endif %}">
 <meta property="og:url" content="{{ site.url }}{{ page.url }}">
 <meta property="og:site_name" content="{{ site.title }}">


### PR DESCRIPTION
Use page layout check to skip appending site name to title and og:title on the home page.