### PR TITLE
Align footer nav and ScanGov Scorecard in same row on tablet and above

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -459,6 +459,15 @@ small { font-size: 0.85rem; }
 
 .footer-nav li { padding: 0; margin: 0; }
 
+@media (min-width: 769px) {
+    .footer-bar > div {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+    }
+    .footer-bar > div > * { margin-top: 0; }
+}
+
 .footer-bar > div > * { margin-top: 0.75rem; }
 .footer-bar > div > *:first-child { margin-top: 0; }
 .footer-bar p { padding: 0; }


### PR DESCRIPTION
Use flexbox with space-between on tablet+ to put nav links left and ScanGov Scorecard right; mobile layout unchanged.