### PR TITLE
Fix dark mode to follow system preference and fix button icon color

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -117,12 +117,12 @@
 <link rel="preload" href="{{ site.baseurl }}/assets/fonts/mona-sans/MonaSans-Regular.woff2" as="font" type="font/woff2" crossorigin fetchpriority="high">
 <link rel="preload" href="{{ site.baseurl }}/assets/fonts/roboto-mono/RobotoMono-Regular.woff2" as="font" type="font/woff2" crossorigin fetchpriority="high">
 
-<!-- Dark mode: apply saved theme before render to prevent flash -->
+<!-- Dark mode: follow system preference -->
 <script>
   (function() {
-    var t = localStorage.getItem('theme');
-    var dark = t === 'dark' || (!t && window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches);
-    if (dark) document.documentElement.classList.add('dark', 'wa-dark');
+    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      document.documentElement.classList.add('dark', 'wa-dark');
+    }
   })();
 </script>
 

--- a/css/style.css
+++ b/css/style.css
@@ -701,3 +701,11 @@ html.dark .svg-inline--fa, html.wa-dark .svg-inline--fa {
     color: var(--site-fg) !important;
     fill: currentColor !important;
 }
+
+html.dark wa-button .fa, html.wa-dark wa-button .fa,
+html.dark wa-button .fa-solid, html.wa-dark wa-button .fa-solid,
+html.dark wa-button .fa-regular, html.wa-dark wa-button .fa-regular,
+html.dark wa-button .fa-brands, html.wa-dark wa-button .fa-brands,
+html.dark wa-button .svg-inline--fa, html.wa-dark wa-button .svg-inline--fa {
+    color: inherit !important;
+}


### PR DESCRIPTION
Remove stale localStorage theme check so dark mode always follows system preference; let FA icons inside wa-button inherit button text color instead of being forced white.